### PR TITLE
Adding a more simple augmentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-toml
+      - id: check-case-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=1024']
+      - id: detect-private-key
+      - id: forbid-new-submodules
+      - id: pretty-format-json
+        args: ['--autofix', '--no-sort-keys', '--indent=4']
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: # arguments to configure flake8
+          # these are errors that will be ignored by flake8
+          # check out their meaning here
+          # https://flake8.pycqa.org/en/latest/user/error-codes.html
+          # Adding args to work with black format
+          - "--max-line-length=79"
+          - "--max-complexity=18"
+          - "--per-file-ignores=__init__.py:F401"
+  -   repo: https://github.com/pre-commit/mirrors-autopep8
+      rev: 'v2.0.2'  # Use the sha / tag you want to point at
+      hooks:
+      -   id: autopep8

--- a/benchmark_utils/augmented_dataset.py
+++ b/benchmark_utils/augmented_dataset.py
@@ -10,6 +10,7 @@ from benchmark_utils.transformation import (
 # - skipping import to speed up autocompletion in CLI.
 # - getting requirements info when all dependencies are not installed.
 with safe_import_context() as import_ctx:
+    from sklearn.utils import resample
     from skorch.helper import to_numpy
 
 
@@ -27,6 +28,8 @@ class AugmentedBCISolver(BaseSolver, ABC):
         pass
 
     def run(self, n_iter):
+        n_samples = [0.1, 0.25, 0.5, 0.7, 1, 2, 5, 7, 10, 20]
+
         """Run the solver to evaluate it for a given number of iterations."""
         if self.augmentation == "ChannelsDropout":
             X, y = channels_dropout(self.X, self.y, n_augmentation=n_iter)
@@ -35,6 +38,10 @@ class AugmentedBCISolver(BaseSolver, ABC):
             X, y = smooth_timemask(
                 self.X, self.y, n_augmentation=n_iter, sfreq=self.sfreq
             )
+        elif self.augmentation == "Sampler":
+            X, y = resample(self.X, self.y,
+                            n_samples=int(len(self.X) * n_samples[n_iter]),
+                            random_state=42)
         else:
             X = to_numpy(self.X)
             y = self.y

--- a/benchmark_utils/transformation.py
+++ b/benchmark_utils/transformation.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 
     from numpy import concatenate
     from torch import as_tensor
-    from skorch.helper import to_numpy
+    from skorch.utils import to_numpy
     from braindecode.augmentation import ChannelsDropout, SmoothTimeMask
 
 

--- a/objective.py
+++ b/objective.py
@@ -10,7 +10,8 @@ with safe_import_context() as import_ctx:
     from sklearn.model_selection import train_test_split
     from sklearn.metrics import balanced_accuracy_score as BAS
 
-    from skorch.helper import SliceDataset, to_numpy
+    from skorch.helper import SliceDataset
+    from skorch.utils import to_numpy
     from benchmark_utils.dataset import split_windows_train_test
 # The benchmark objective must be named `Objective` and
 # inherit from `BaseObjective` for `benchopt` to work properly.

--- a/solvers/MOABB.py
+++ b/solvers/MOABB.py
@@ -1,26 +1,28 @@
 from benchopt import safe_import_context
-
+from benchmark_utils.pipeline import parser_pipelines
+from benchmark_utils.augmented_dataset import (
+    AugmentedBCISolver,
+)
 # Protect the import with `safe_import_context()`. This allows:
 # - skipping import to speed up autocompletion in CLI.
 # - getting requirements info when all dependencies are not installed.
 with safe_import_context() as import_ctx:
-    from skorch.helper import to_numpy
-
-    from benchmark_utils.pipeline import parser_pipelines
-    from benchmark_utils.augmented_dataset import (
-        AugmentedBCISolver,
-    )
+    from skorch.utils import to_numpy
 
 
 class Solver(AugmentedBCISolver):
     name = "MOABBPipelines"
+
+    moabb_url = 'git+https://github.com/bruAristimunha/moabb@develop#egg=moabb'
+    install_cmd = 'pip'
+    requirements = ['skorch',
+                    moabb_url]
+
     parameters = {
-        "augmentation": ["SmoothTimeMask",
-                         "IdentityTransform"],
+        "augmentation": ["Sampler"],
         "pipeline": [
             "AUGTangSVMGrid",
             "MDM",
-            "MDMAug",
             "TangentSpaceSVMGrid",
             "COVCSPLDA",
             "FgMDM",
@@ -33,6 +35,7 @@ class Solver(AugmentedBCISolver):
             "TRCSPLDA",
             "DUMMY",
         ],
+
     }
 
     def set_objective(self, X, y, sfreq):


### PR DESCRIPTION
Hi everyone!

I'm introducing a more basic augmentation technique for the benchmark BCI module. This augmentation samples trials with a bootstrapping method, which effectively increases the size of the dataset by repetition.

I've also added some convenience features, such as a pre-commit module, to avoid problems with CI.

I've tested this augmentation on a BCI Competition, and it works well. Once we have the cross-validation part working, I think we have all the necessary tools to run the experiments for a paper.